### PR TITLE
【feature/19】Profile表示用の絵画を取得するAPIを作成

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -5,13 +5,7 @@ class Api::V1::UsersController < ApplicationController
 
   # GET /api/v1/users/profile
   def me
-    render json: UserSerializer.new(
-      current_user,
-      include: [
-        :pictures, :'pictures.user', :'pictures.likes', :'pictures.comments',
-        :liked_pictures, :'liked_pictures.user', :'liked_pictures.likes', :'liked_pictures.comments'
-      ]
-    ).serializable_hash, status: :ok
+    render json: UserSerializer.new(current_user).serializable_hash, status: :ok
   end
 
   # PATCH /api/v1/users/profile

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::UsersController < ApplicationController
   include JwtAuthenticatable
   skip_before_action :authenticate_request, only: %i[create]
+  before_action :set_user, only: %i[pictures liked_pictures]
 
   # GET /api/v1/users/profile
   def me
@@ -38,12 +39,24 @@ class Api::V1::UsersController < ApplicationController
     render json: { error: "ログインに失敗しました: #{e.message}" }, status: :internal_server_error
   end
 
-  # GET /api/v1/users/:id
+  # GET /api/v1/users/:uid
   def show
     render json: UserSerializer.new(current_user).serializable_hash.to_json, status: :ok
   end
 
-  # DELETE /api/v1/users/:id
+  # GET /api/v1/users/:uid/pictures
+  def pictures
+    pictures = @user.pictures.includes([:likes, :theme, :comments]).order(created_at: :desc)
+    render json: PictureSerializer.new(pictures, include: [:user, :theme, :likes]).serializable_hash, status: :ok
+  end
+
+  # GET /api/v1/users/:uid/liked_pictures
+  def liked_pictures
+    pictures = @user.liked_pictures.includes([:likes, :theme, :comments]).order(created_at: :desc)
+    render json: PictureSerializer.new(pictures, include: [:user, :theme, :likes]).serializable_hash, status: :ok
+  end
+
+  # DELETE /api/v1/users/:uid
   def destroy
     current_user.soft_destroy!
     render json: { message: "ユーザーを削除しました" }, status: :ok
@@ -55,5 +68,9 @@ class Api::V1::UsersController < ApplicationController
 
     def user_params
       params.require(:user).permit(:name, :email, :image)
+    end
+
+    def set_user
+      @user = User.find_by(uid: params[:uid])
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,13 +15,7 @@ class ApplicationController < ActionController::API
       token = request.headers["Authorization"]&.split(" ")&.last
       decoded_token = decode(token)
       if decoded_token
-        if action_name == "me"
-          @current_user = User.includes(pictures: [:likes, :comments],
-                                        liked_pictures: [:likes,
-                                                         :comments]).find_by(id: decoded_token[:user_id])
-        else
-          @current_user = User.find_by(id: decoded_token[:user_id])
-        end
+        @current_user = User.find_by(id: decoded_token[:user_id])
       else
         render json: { error: "Not Authorized" }, status: :unauthorized unless @current_user
       end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,7 +1,7 @@
 class UserSerializer
   include JSONAPI::Serializer
   set_type :user
-  attributes :name, :email, :image
+  attributes :name, :email, :image, :uid
 
   has_many :pictures, serializer: PictureSerializer
   has_many :liked_pictures, serializer: PictureSerializer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,16 +2,23 @@ Rails.application.routes.draw do
   post 'auth/:provider/callback', to: 'api/v1/users#create'
   namespace :api, format: 'json' do
     namespace :v1 do
-      resources :users, only: %i[create show destroy] do
+      resources :users, only: %i[create show destroy], param: :uid do
         collection do
           get 'me', to: 'users#me'
           put 'profile', to: 'users#update_profile'
         end
+        
+        member do
+          get 'pictures', to: 'users#pictures'
+          get 'liked_pictures', to: 'users#liked_pictures'
+        end
       end
+
       resources :themes, only: %i[index show create update destroy]
       resources :pictures, only: %i[index create update destroy] do
         resources :comments, only: %i[index show create update destroy]
       end
+
       resources :likes, param: :picture_uid, only: %i[create destroy]
     end
   end

--- a/spec/requests/api/v1/themes_spec.rb
+++ b/spec/requests/api/v1/themes_spec.rb
@@ -1,15 +1,15 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Themes", type: :request do
-  let!(:user) { create(:user) }
-  let!(:token) { encode_jwt({ user_id: user.id }) }
-  let!(:headers) { { Authorization: "Bearer #{token}" } }
+  let(:user) { create(:user) }
+  let(:token) { encode_jwt({ user_id: user.id }) }
+  let(:headers) { { Authorization: "Bearer #{token}" } }
 
   describe "GET /api/v1/themes" do
-    let!(:themes) { create_list(:theme, 3) }
+    before { create_list(:theme, 3) }
 
     context "when the user gets the themes" do
-      before { get api_v1_themes_path, headers: headers }
+      before { get api_v1_themes_path, headers: }
 
       it "returns status ok" do
         expect(response).to have_http_status(:ok)

--- a/spec/requests/api/v1/themes_spec.rb
+++ b/spec/requests/api/v1/themes_spec.rb
@@ -1,7 +1,31 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Themes", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let!(:user) { create(:user) }
+  let!(:token) { encode_jwt({ user_id: user.id }) }
+  let!(:headers) { { Authorization: "Bearer #{token}" } }
+
+  describe "GET /api/v1/themes" do
+    let!(:themes) { create_list(:theme, 3) }
+
+    context "when the user gets the themes" do
+      before { get api_v1_themes_path, headers: headers }
+
+      it "returns status ok" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns themes" do
+        expect(JSON.parse(response.body)["data"].length).to eq(3)
+      end
+    end
+
+    context "when unauthorized" do
+      before { get api_v1_themes_path }
+
+      it "returns status unauthorized" do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -66,14 +66,14 @@ RSpec.describe User, type: :request do
     end
   end
 
-  describe "PATCH /api/v1/users/profile" do
+  describe "PUT /api/v1/users/profile" do
     let!(:user) { create(:user) }
     let!(:token) { encode_jwt({ user_id: user.id }) }
     let!(:headers) { { Authorization: "Bearer #{token}" } }
 
     context "when valid request without image" do
       before do
-        patch "/api/v1/users/profile", params: { user: { name: "new_name" } }, headers:
+        put "/api/v1/users/profile", params: { user: { name: "new_name" } }, headers:
       end
 
       it "returns status ok" do
@@ -87,7 +87,7 @@ RSpec.describe User, type: :request do
 
     context "when valid request with image" do
       before do
-        patch "/api/v1/users/profile", params: { user: { name: "new_name", image: "files/test.jpg" } }, headers:
+        put "/api/v1/users/profile", params: { user: { name: "new_name", image: "files/test.jpg" } }, headers:
       end
 
       it "returns status ok" do
@@ -101,7 +101,7 @@ RSpec.describe User, type: :request do
 
     context "when valid request without name" do
       before do
-        patch "/api/v1/users/profile", params: { user: { image: "files/test.jpg" } }, headers:
+        put "/api/v1/users/profile", params: { user: { image: "files/test.jpg" } }, headers:
       end
 
       it "returns status ok" do
@@ -115,7 +115,7 @@ RSpec.describe User, type: :request do
 
     context "when invalid request" do
       before do
-        patch "/api/v1/users/profile", params: { user: { name: nil } }, headers:
+        put "/api/v1/users/profile", params: { user: { name: nil } }, headers:
       end
 
       it "returns internal_server_error status" do

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -127,4 +127,72 @@ RSpec.describe User, type: :request do
       end
     end
   end
+
+  describe "GET /api/v1/users/:id/pictures" do
+    let!(:user) { create(:user) }
+    let!(:token) { encode_jwt({ user_id: user.id }) }
+    let!(:headers) { { Authorization: "Bearer #{token}" } }
+    let!(:theme) { create(:theme) }
+
+    before do
+      create_list(:picture, 3, user:, theme:)
+      get "/api/v1/users/#{user.uid}/pictures", headers:
+    end
+
+    context "when valid request" do
+      it "returns status ok" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns pictures" do
+        expect(JSON.parse(response.body)["data"].length).to eq(3)
+      end
+    end
+
+    context "when unauthorized request" do
+      before do
+        get "/api/v1/users/#{user.uid}/pictures"
+      end
+
+      it "returns unauthorized status" do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /api/v1/users/:id/liked_pictures" do
+    let(:user) { create(:user) }
+    let(:token) { encode_jwt({ user_id: user.id }) }
+    let(:headers) { { Authorization: "Bearer #{token}" } }
+
+    before do
+      theme = create(:theme)
+      picture = create(:picture, theme:)
+      create(:like, user:, picture:)
+    end
+
+    context "when valid request" do
+      before do
+        get "/api/v1/users/#{user.uid}/liked_pictures", headers:
+      end
+
+      it "returns status ok" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns pictures" do
+        expect(JSON.parse(response.body)["data"].length).to eq(1)
+      end
+    end
+
+    context "when unauthorized request" do
+      before do
+        get "/api/v1/users/#{user.uid}/liked_pictures"
+      end
+
+      it "returns not_fouunauthorizednd status" do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 実装の概要

以下のとおり、実装。

- プロフィール用絵画・いいねした絵画の取得API実装
- RSpec記述

## Issue

- #19 

## 実装理由・気づき

- Herokuへのgithubactionsを作成せねば。

## 最後に

close #19 
